### PR TITLE
Adds affiliations article.

### DIFF
--- a/src/SGA_Constitution.tex
+++ b/src/SGA_Constitution.tex
@@ -144,4 +144,8 @@ Acceptance of any amendment to the constitution will require \sfrac{2}{3} vote w
 
 Amendments are subject to the approval of the Student Government Association and the Student Activities Committee.
 
+\carticle{External Affiliations}
+
+RoboJackets is affiliated with RoboJackets, Inc., a Georgia non-profit corporation.
+
 \end{document}


### PR DESCRIPTION
This PR adds an article acknowledging the affiliation between the student organization and the corporation.

Per [Georgia Tech's RSO policy](https://policylibrary.gatech.edu/registered-student-organizations-policy), section 5.7, the constitution must include
> Identification of any affiliations with local, regional, national, or international entities or organizations; 